### PR TITLE
Fix: uniquely identifies list item

### DIFF
--- a/src/modules/projects/ProjectPage.tsx
+++ b/src/modules/projects/ProjectPage.tsx
@@ -41,8 +41,8 @@ const ProjectPage = ({projects, refreshData}: Props) => {
 
       {/* project list */}
       <ul>
-        {projects && projects.map((project, index) => (
-          <li className="w-full flex justify-between mb-5" key={index}>
+        {projects && projects.map((project) => (
+          <li className="w-full flex justify-between mb-5" key={project.id}>
             <Project project={project} refreshData={refreshData} />
           </li>
         ))}


### PR DESCRIPTION
React doc: The best way to pick a key is to use a string that uniquely identifies a list item among its siblings. Most often you would use IDs from your data as keys. When you don’t have stable IDs for rendered items, you may use the item index as a key as a last resort !!We don’t recommend using indexes for keys if the order of items may change. This can negatively impact performance and may cause issues with component state.. !!